### PR TITLE
Refactored HeadersDsl and added disable option for headers

### DIFF
--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/HttpSecurityDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/HttpSecurityDsl.kt
@@ -246,8 +246,7 @@ class HttpSecurityDsl(private val http: HttpSecurity, private val init: HttpSecu
      * @see [HeadersDsl]
      */
     fun headers(headersConfiguration: HeadersDsl.() -> Unit) {
-        val headersCustomizer = HeadersDsl().apply(headersConfiguration).get()
-        this.http.headers(headersCustomizer)
+        HeadersDsl(http.headers()).apply(headersConfiguration)
     }
 
     /**

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/CacheControlDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/CacheControlDsl.kt
@@ -26,8 +26,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * @author Eleftheria Stein
  * @since 5.2
  */
-class CacheControlDsl {
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.CacheControlConfig) -> Unit {
-        return { }
+class CacheControlDsl(
+        private val cacheControlConfig: HeadersConfigurer<HttpSecurity>.CacheControlConfig
+) {
+
+    fun disable() {
+        cacheControlConfig.disable()
     }
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ContentSecurityPolicyDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ContentSecurityPolicyDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 
 /**
  * A Kotlin DSL to configure the [HttpSecurity] Content-Security-Policy header using
@@ -28,20 +29,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * @property policyDirectives the security policy directive(s) to be used in the response header.
  * @property reportOnly includes the Content-Security-Policy-Report-Only header in the response.
  */
-class ContentSecurityPolicyDsl {
-    var policyDirectives: String? = null
-    var reportOnly: Boolean? = null
+class ContentSecurityPolicyDsl(
+        private val contentSecurityPolicyConfig: HeadersConfigurer<HttpSecurity>.ContentSecurityPolicyConfig
+) {
 
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.ContentSecurityPolicyConfig) -> Unit {
-        return { contentSecurityPolicy ->
-            policyDirectives?.also {
-                contentSecurityPolicy.policyDirectives(policyDirectives)
-            }
-            reportOnly?.also {
-                if (reportOnly!!) {
-                    contentSecurityPolicy.reportOnly()
-                }
-            }
-        }
-    }
+    var policyDirectives by CallbackDelegates.callOnSet(contentSecurityPolicyConfig::policyDirectives)
+    var reportOnly by CallbackDelegates.callOnSet(contentSecurityPolicyConfig::reportOnly)
+
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/FrameOptionsDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/FrameOptionsDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 
 /**
  * A Kotlin DSL to configure the [HttpSecurity] X-Frame-Options header using
@@ -29,22 +30,13 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * application.
  * @property deny deny framing any content from this application.
  */
-class FrameOptionsDsl {
-    var sameOrigin: Boolean? = null
-    var deny: Boolean? = null
+class FrameOptionsDsl(
+        private val frameOptionsConfig: HeadersConfigurer<HttpSecurity>.FrameOptionsConfig
+) {
+    var sameOrigin by CallbackDelegates.callOnSet(frameOptionsConfig::sameOrigin)
+    var deny by CallbackDelegates.callOnSet(frameOptionsConfig::deny)
 
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.FrameOptionsConfig) -> Unit {
-        return { frameOptions ->
-            sameOrigin?.also {
-                if (sameOrigin!!) {
-                    frameOptions.sameOrigin()
-                }
-            }
-            deny?.also {
-                if (deny!!) {
-                    frameOptions.deny()
-                }
-            }
-        }
+    fun disable() {
+        frameOptionsConfig.disable()
     }
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpPublicKeyPinningDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpPublicKeyPinningDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 
 /**
  * A Kotlin DSL to configure the [HttpSecurity] HTTP Public Key Pinning header using
@@ -34,30 +35,16 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * the server.
  * @property reportUri the URI to which the browser should report pin validation failures.
  */
-class HttpPublicKeyPinningDsl {
-    var pins: Map<String, String>? = null
-    var maxAgeInSeconds: Long? = null
-    var includeSubDomains: Boolean? = null
-    var reportOnly: Boolean? = null
-    var reportUri: String? = null
+class HttpPublicKeyPinningDsl(
+        private val hpkpConfig: HeadersConfigurer<HttpSecurity>.HpkpConfig
+) {
+    var pins: Map<String, String>? by CallbackDelegates.callOnSet(hpkpConfig::withPins)
+    var maxAgeInSeconds by CallbackDelegates.callOnSet(hpkpConfig::maxAgeInSeconds)
+    var includeSubDomains by CallbackDelegates.callOnSet(hpkpConfig::includeSubDomains)
+    var reportOnly by CallbackDelegates.callOnSet(hpkpConfig::reportOnly)
+    var reportUri by CallbackDelegates.callOnSet<String>(hpkpConfig::reportUri)
 
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.HpkpConfig) -> Unit {
-        return { hpkp ->
-            pins?.also {
-                hpkp.withPins(pins)
-            }
-            maxAgeInSeconds?.also {
-                hpkp.maxAgeInSeconds(maxAgeInSeconds!!)
-            }
-            includeSubDomains?.also {
-                hpkp.includeSubDomains(includeSubDomains!!)
-            }
-            reportOnly?.also {
-                hpkp.reportOnly(reportOnly!!)
-            }
-            reportUri?.also {
-                hpkp.reportUri(reportUri)
-            }
-        }
+    fun disable() {
+        hpkpConfig.disable()
     }
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpStrictTransportSecurityDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpStrictTransportSecurityDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 import org.springframework.security.web.util.matcher.RequestMatcher
 
 /**
@@ -34,18 +35,15 @@ import org.springframework.security.web.util.matcher.RequestMatcher
  * @property includeSubDomains if true, subdomains should be considered HSTS Hosts too.
  * @property preload if true, preload will be included in HSTS Header.
  */
-class HttpStrictTransportSecurityDsl {
-    var maxAgeInSeconds: Long? = null
-    var requestMatcher: RequestMatcher? = null
-    var includeSubDomains: Boolean? = null
-    var preload: Boolean? = null
+class HttpStrictTransportSecurityDsl(
+        private val hstsConfig: HeadersConfigurer<HttpSecurity>.HstsConfig
+) {
+    var maxAgeInSeconds by CallbackDelegates.callOnSet(hstsConfig::maxAgeInSeconds)
+    var requestMatcher by CallbackDelegates.callOnSet<RequestMatcher>(hstsConfig::requestMatcher)
+    var includeSubDomains by CallbackDelegates.callOnSet(hstsConfig::includeSubDomains)
+    var preload by CallbackDelegates.callOnSet(hstsConfig::preload)
 
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.HstsConfig) -> Unit {
-        return { hsts ->
-            maxAgeInSeconds?.also { hsts.maxAgeInSeconds(maxAgeInSeconds!!) }
-            requestMatcher?.also { hsts.requestMatcher(requestMatcher) }
-            includeSubDomains?.also { hsts.includeSubDomains(includeSubDomains!!) }
-            preload?.also { hsts.preload(preload!!) }
-        }
+    fun disable() {
+        hstsConfig.disable()
     }
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ReferrerPolicyDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ReferrerPolicyDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter
 
 /**
@@ -28,14 +29,8 @@ import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWrite
  * @since 5.2
  * @property policy the policy to be used in the response header.
  */
-class ReferrerPolicyDsl {
-    var policy: ReferrerPolicyHeaderWriter.ReferrerPolicy? = null
-
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.ReferrerPolicyConfig) -> Unit {
-        return { referrerPolicy ->
-            policy?.also {
-                referrerPolicy.policy(policy)
-            }
-        }
-    }
+class ReferrerPolicyDsl(
+        private val referrerPolicyConfig: HeadersConfigurer<HttpSecurity>.ReferrerPolicyConfig
+) {
+    var policy by CallbackDelegates.callOnSet(referrerPolicyConfig::policy)
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/XssProtectionConfigDsl.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/XssProtectionConfigDsl.kt
@@ -18,6 +18,7 @@ package org.springframework.security.dsl.config.builders.servlet.headers
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import org.springframework.security.dsl.config.builders.util.delegates.CallbackDelegates
 
 /**
  * A Kotlin DSL to configure the [HttpSecurity] XSS protection header using
@@ -29,14 +30,13 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
  * @property xssProtectionEnabled if true, the header value will contain a value of 1.
  * If false, will explicitly disable specify that X-XSS-Protection is disabled.
  */
-class XssProtectionConfigDsl {
-    var block: Boolean? = null
-    var xssProtectionEnabled: Boolean? = null
+class XssProtectionConfigDsl(
+        private val xXssConfig: HeadersConfigurer<HttpSecurity>.XXssConfig
+) {
+    var block by CallbackDelegates.callOnSet(xXssConfig::block)
+    var xssProtectionEnabled by CallbackDelegates.callOnSet(xXssConfig::xssProtectionEnabled)
 
-    internal fun get(): (HeadersConfigurer<HttpSecurity>.XXssConfig) -> Unit {
-        return { xssProtection ->
-            block?.also { xssProtection.block(block!!) }
-            xssProtectionEnabled?.also { xssProtection.xssProtectionEnabled(xssProtectionEnabled!!) }
-        }
+    fun disable() {
+        xXssConfig.disable()
     }
 }

--- a/src/main/kotlin/org/springframework/security/dsl/config/builders/util/delegates/CallbackDelegates.kt
+++ b/src/main/kotlin/org/springframework/security/dsl/config/builders/util/delegates/CallbackDelegates.kt
@@ -14,24 +14,26 @@
  * limitations under the License.
  */
 
-package org.springframework.security.dsl.config.builders.servlet.headers
+package org.springframework.security.dsl.config.builders.util.delegates
 
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer
+import kotlin.properties.Delegates
 
 /**
- * A Kotlin DSL to configure [HttpSecurity] X-Content-Type-Options header using idiomatic
- * Kotlin code.
+ * Observing delegate functions to trigger a callback function when the observed property is changed.
  *
- * @author Eleftheria Stein
+ * @author Daniel Stoll
  * @since 5.2
  */
-class ContentTypeOptionsDsl(
-        private val contentTypeOptionsConfig: HeadersConfigurer<HttpSecurity>.ContentTypeOptionsConfig
-) {
+class CallbackDelegates {
+    companion object {
 
-    fun disable() {
-        contentTypeOptionsConfig.disable()
+        fun callOnSet(method: () -> Any?) = Delegates.observable(false) {
+            _, _, new -> if (new) method.invoke()
+        }
+
+        fun <T> callOnSet(method: (T) -> Any?) = Delegates.observable<T?>(null) {
+            _, _, new: T? -> new?.let { method.invoke(new) }
+        }
+
     }
-
 }

--- a/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ContentTypeOptionsDslTests.kt
+++ b/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/ContentTypeOptionsDslTests.kt
@@ -62,4 +62,27 @@ class ContentTypeOptionsDslTests {
             }
         }
     }
+
+    @Test
+    fun `headers when content type options disabled then no content type options header in response`() {
+        this.spring.register(ContentTypeOptionsDisabledConfig::class.java).autowire()
+
+        this.mockMvc.get("/")
+                .andExpect {
+                    header { doesNotExist(ContentTypeOptionsServerHttpHeadersWriter.X_CONTENT_OPTIONS) }
+                }
+    }
+
+    @EnableWebSecurity
+    class ContentTypeOptionsDisabledConfig : WebSecurityConfigurerAdapter() {
+        override fun configure(http: HttpSecurity) {
+            http {
+                headers {
+                    contentTypeOptions {
+                        disable()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/FrameOptionsDslTests.kt
+++ b/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/FrameOptionsDslTests.kt
@@ -140,4 +140,28 @@ class FrameOptionsDslTests {
             }
         }
     }
+
+    @Test
+    fun `headers when frame options disabled then no frame option header in response`() {
+        this.spring.register(FrameOptionsDisabledConfig::class.java).autowire()
+
+        this.mockMvc.get("/") {
+            secure = true
+        }.andExpect {
+            header { doesNotExist(XFrameOptionsServerHttpHeadersWriter.X_FRAME_OPTIONS) }
+        }
+    }
+
+    @EnableWebSecurity
+    class FrameOptionsDisabledConfig : WebSecurityConfigurerAdapter() {
+        override fun configure(http: HttpSecurity) {
+            http {
+                headers {
+                    frameOptions {
+                        disable()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpPublicKeyPinningDslTests.kt
+++ b/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpPublicKeyPinningDslTests.kt
@@ -197,4 +197,28 @@ class HttpPublicKeyPinningDslTests {
             }
         }
     }
+
+    @Test
+    fun `headers when hpkp disabled then no hpkp header in response`() {
+        this.spring.register(HpkpDisabledConfig::class.java).autowire()
+
+        this.mockMvc.get("/") {
+            secure = true
+        }.andExpect {
+            header { doesNotExist(HPKP_RO_HEADER_NAME) }
+        }
+    }
+
+    @EnableWebSecurity
+    class HpkpDisabledConfig : WebSecurityConfigurerAdapter() {
+        override fun configure(http: HttpSecurity) {
+            http {
+                headers {
+                    httpPublicKeyPinning {
+                        disable()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpStrictTransportSecurityDslTests.kt
+++ b/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/HttpStrictTransportSecurityDslTests.kt
@@ -140,4 +140,28 @@ class HttpStrictTransportSecurityDslTests {
             }
         }
     }
+
+    @Test
+    fun `headers when hsts disabled then no hsts header in response`() {
+        this.spring.register(HstsDisabledConfig::class.java).autowire()
+
+        this.mockMvc.get("/") {
+            secure = true
+        }.andExpect {
+            header { doesNotExist(StrictTransportSecurityServerHttpHeadersWriter.STRICT_TRANSPORT_SECURITY) }
+        }
+    }
+
+    @EnableWebSecurity
+    class HstsDisabledConfig : WebSecurityConfigurerAdapter() {
+        override fun configure(http: HttpSecurity) {
+            http {
+                headers {
+                    httpStrictTransportSecurity {
+                        disable()
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/XssProtectionConfigDslTests.kt
+++ b/src/test/kotlin/org/springframework/security/dsl/config/builders/servlet/headers/XssProtectionConfigDslTests.kt
@@ -113,4 +113,28 @@ class XssProtectionConfigDslTests {
             }
         }
     }
+
+    @Test
+    fun `headers when XssProtection disabled via method then no X-Xss-Protection header in response`() {
+        this.spring.register(XssProtectionDisabledViaMethodConfig::class.java).autowire()
+
+        this.mockMvc.get("/") {
+            secure = true
+        }.andExpect {
+            header { doesNotExist(XXssProtectionServerHttpHeadersWriter.X_XSS_PROTECTION) }
+        }
+    }
+
+    @EnableWebSecurity
+    class XssProtectionDisabledViaMethodConfig : WebSecurityConfigurerAdapter() {
+        override fun configure(http: HttpSecurity) {
+            http {
+                headers {
+                    xssProtection {
+                        disable()
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
 - Refactored the HeadersDsl to use HeadersConfigurer and its properties.

 - The individual header configurations are now applied directly to the fields of HeadersConfigurer.

 - Added a custom disable option for all headers where Spring Security allows custom deactivation.

- Added tests that check the individual deactivation of headers.

Fixes #9 